### PR TITLE
Update the if statement to only applicable to postgres sql

### DIFF
--- a/src/main/java/com/rapiddweller/jdbacl/model/jdbc/JDBCDBImporter.java
+++ b/src/main/java/com/rapiddweller/jdbacl/model/jdbc/JDBCDBImporter.java
@@ -405,7 +405,7 @@ public class JDBCDBImporter implements DBMetaDataImporter {
         while (resultSet.next()) {
           set.add((String) resultSet.getObject("TABLE_SCHEM"));
         }
-      } else if (!this.dialect.getSystem().equals("sql_server")) {
+      } else if (this.dialect.getSystem().equals("postgres")) {
         ResultSet resultSet = metaData.getImportedKeys(null, schemaName, null);
         while (resultSet.next()) {
           set.add((String) resultSet.getObject("PKTABLE_SCHEM"));


### PR DESCRIPTION
Update the if statement to only applicable to postgres sql, for other dialect that do not have specific logic will return the only schema in JDBCDBImporter as the needed schema.